### PR TITLE
Added Block Focus Option

### DIFF
--- a/src/data/inject.js
+++ b/src/data/inject.js
@@ -54,22 +54,29 @@ script.textContent = `
       });
     }
     document.addEventListener('blur', e => script.dataset.blur !== 'false' && block(e), true);
+    document.addEventListener('focus', e => script.dataset.focus !== 'false' && block(e), true);
     window.addEventListener('blur', e => script.dataset.blur !== 'false' && block(e), true);
     window.addEventListener('mouseleave', e => script.dataset.mouseleave !== 'false' && block(e), true);
+    window.addEventListener('focus', e => script.dataset.focus !== 'false' && block(e), true);
   }
 `;
 document.documentElement.appendChild(script);
 script.remove();
 chrome.storage.local.get({
   'blur': true,
-  'mouseleave': true
+  'mouseleave': true,
+  'focus': true
 }, prefs => {
   script.dataset.blur = prefs.blur;
   script.dataset.mouseleave = prefs.mouseleave;
+  script.dataset.focus = prefs.focus;
 });
 chrome.storage.onChanged.addListener(prefs => {
   if (prefs.blur) {
     script.dataset.blur = prefs.blur.newValue;
+  }
+  if (prefs.focus) {
+    script.dataset.focus = prefs.focus.newValue;
   }
   if (prefs.mouseleave) {
     script.dataset.mouseleave = prefs.mouseleave.newValue;

--- a/src/data/options/index.html
+++ b/src/data/options/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <title>Always active Window - Always Visible :: Options Page</title>
   <style type="text/css">
@@ -8,12 +9,14 @@
       grid-template-columns: min-content 1fr;
       grid-gap: 10px;
     }
+
     .disabled {
       opacity: 0.4;
       pointer-events: none;
     }
   </style>
 </head>
+
 <body>
   <div class="grid">
     <input class="disabled" type="checkbox" id="visibilityState">
@@ -22,6 +25,8 @@
     <label class="disabled" for="hidden">Overwrite "document.hidden"</label>
     <input type="checkbox" id="blur">
     <label for="blur">Block "blur" event</label>
+    <input type="checkbox" id="focus">
+    <label for="focus">Block "focus" event</label>
     <input type="checkbox" id="mouseleave">
     <label for="mouseleave">Block "mouseleave" event</label>
   </div>
@@ -34,4 +39,5 @@
     <script type="text/javascript" src="index.js"></script>
   </p>
 </body>
+
 </html>

--- a/src/data/options/index.js
+++ b/src/data/options/index.js
@@ -4,19 +4,22 @@ chrome.storage.local.get({
   'visibilityState': true,
   'hidden': true,
   'blur': true,
-  'mouseleave': true
+  'mouseleave': true,
+  'focus': true
 }, prefs => {
   document.getElementById('visibilityState').checked = prefs.visibilityState;
   document.getElementById('hidden').checked = prefs.hidden;
   document.getElementById('blur').checked = prefs.blur;
   document.getElementById('mouseleave').checked = prefs.mouseleave;
+  document.getElementById('focus').checked = prefs.focus;
 });
 
 document.getElementById('save').addEventListener('click', () => chrome.storage.local.set({
   'visibilityState': document.getElementById('visibilityState').checked,
   'hidden': document.getElementById('hidden').checked,
   'blur': document.getElementById('blur').checked,
-  'mouseleave': document.getElementById('mouseleave').checked
+  'mouseleave': document.getElementById('mouseleave').checked,
+  'focus': document.getElementById('focus').checked
 }, () => {
   toast.textContent = 'Options Saved';
   setTimeout(() => toast.textContent = '', 1000);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,15 +23,19 @@
       "background.js"
     ]
   },
-  "content_scripts": [{
-    "matches": ["<all_urls>"],
-    "run_at": "document_start",
-    "all_frames": true,
-    "match_about_blank": true,
-    "js": [
-      "data/inject.js"
-    ]
-  }],
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "run_at": "document_start",
+      "all_frames": true,
+      "match_about_blank": true,
+      "js": [
+        "data/inject.js"
+      ]
+    }
+  ],
   "options_ui": {
     "page": "data/options/index.html",
     "chrome_style": true


### PR DESCRIPTION
Was useful for me to block in a certain webpage which used to add anomaly to the page when triggering focus without blur first and its completely optional to enable if but I may have left it enabled by default. change that if you wish and sorry, Its not such a big feature.

![image](https://user-images.githubusercontent.com/45287301/108369502-a99c1d80-7221-11eb-87e1-3431c708396d.png)

To check you can use the following JavaScript on any website with jQuery.
```js
var i = 0;
$(window).focus(function() {
    i++;
    console.log(i);
});
$(window).blur(function() {
    console.log("Tabbed Out");
});
```